### PR TITLE
Add get_operation util

### DIFF
--- a/ariadne_graphql_proxy/__init__.py
+++ b/ariadne_graphql_proxy/__init__.py
@@ -18,6 +18,7 @@ from .copy import (
     copy_schema_types,
     copy_union,
 )
+from .get_operation import get_operation
 from .merge import (
     merge_args,
     merge_enums,
@@ -56,6 +57,7 @@ __all__ = [
     "copy_schema_type",
     "copy_schema_types",
     "copy_union",
+    "get_operation",
     "merge_args",
     "merge_enums",
     "merge_enums_values",

--- a/ariadne_graphql_proxy/get_operation.py
+++ b/ariadne_graphql_proxy/get_operation.py
@@ -1,0 +1,57 @@
+from typing import List, Optional, cast
+
+from graphql import (
+    DocumentNode,
+    GraphQLError,
+    OperationDefinitionNode,
+)
+
+
+def get_operation(
+    document: DocumentNode,
+    operation_name: Optional[str] = None,
+) -> OperationDefinitionNode:
+    operations: List[OperationDefinitionNode] = []
+    anonymous_operations = 0
+
+    for definition in document.definitions:
+        if isinstance(definition, OperationDefinitionNode):
+            operations.append(definition)
+            if not definition.name:
+                anonymous_operations += 1
+
+    if not operations:
+        raise GraphQLError(f"Query did not contain any operations.")
+
+    if len(operations) == 1:
+        operation = operations[0]
+
+        if not operation_name:
+            return operation
+
+        if not operation.name or operation.name.value != operation_name:
+            raise UnknownOperationGraphQLError(operation_name)
+
+        return operation
+
+    if anonymous_operations == 1:
+        raise GraphQLError("Query can't define both anonymous and named operations.")
+
+    if anonymous_operations > 1:
+        raise GraphQLError("Query can't define multiple anonymous operations.")
+
+    if not operation_name:
+        raise GraphQLError(
+            "Operation name is required if query contains multiple operations."
+        )
+
+    for operation in operations:
+        if operation.name and operation.name.value == operation_name:
+            return operation
+
+    raise UnknownOperationGraphQLError(operation_name)
+
+
+class UnknownOperationGraphQLError(GraphQLError):
+    def __init__(self, operation_name: str):
+        super().__init__(f"Unknown operation named '{operation_name}'.")

--- a/tests/test_get_operation.py
+++ b/tests/test_get_operation.py
@@ -1,0 +1,91 @@
+import pytest
+from graphql import GraphQLError, parse
+
+from ariadne_graphql_proxy import get_operation
+
+
+def test_only_anonymous_operation_is_returned():
+    document = parse("{ hello }")
+    assert get_operation(document)
+
+
+def test_only_named_operation_is_returned():
+    document = parse("query Hello { hello }")
+    operation = get_operation(document)
+    assert operation.name.value == "Hello"
+
+
+def test_only_named_operation_is_returned_by_name():
+    document = parse("query Hello { hello }")
+    operation = get_operation(document, "Hello")
+    assert operation.name.value == "Hello"
+
+
+def test_named_operation_is_returned_by_name():
+    document = parse(
+        """
+        query Hello { hello }
+        
+        query User { user { id name } }
+        """
+    )
+    operation = get_operation(document, "User")
+    assert operation.name.value == "User"
+
+
+def test_error_is_raised_if_operation_with_name_is_not_found():
+    with pytest.raises(GraphQLError) as excinfo:
+        document = parse(
+            """
+            query Hello { hello }
+            
+            query User { user { id name } }
+            """
+        )
+        get_operation(document, "Test")
+
+    assert "Unknown operation named 'Test'." == str(excinfo.value)
+
+
+def test_error_is_raised_if_multiple_operations_are_defined_but_no_name_is_given():
+    with pytest.raises(GraphQLError) as excinfo:
+        document = parse(
+            """
+            query Hello { hello }
+            
+            query User { user { id name } }
+            """
+        )
+        get_operation(document)
+
+    assert "Operation name is required" in str(excinfo.value)
+
+
+def test_error_is_raised_if_query_has_multiple_anonymous_operations():
+    with pytest.raises(GraphQLError) as excinfo:
+        document = parse(
+            """
+            { hello }
+            
+            { user { id name } }
+            """
+        )
+        get_operation(document)
+
+    assert "Query can't define multiple anonymous operations." == str(excinfo.value)
+
+
+def test_error_is_raised_if_query_has_combines_anonymous_and_named_operations():
+    with pytest.raises(GraphQLError) as excinfo:
+        document = parse(
+            """
+            query Hello { hello }
+            
+            { user { id name } }
+            """
+        )
+        get_operation(document)
+
+    assert "Query can't define both anonymous and named operations." == str(
+        excinfo.value
+    )


### PR DESCRIPTION
This PR adds finalized `get_operation` utility from #8 that can be used to pull operation from query document.