### PR TITLE
Fix QueryFilter to get type of fragment from type condition

### DIFF
--- a/ariadne_graphql_proxy/query_filter.py
+++ b/ariadne_graphql_proxy/query_filter.py
@@ -258,7 +258,7 @@ class QueryFilter:
         if not fragment:
             return []
 
-        type_name = fragment.name.value
+        type_name = fragment.type_condition.name.value
         type_fields = self.fields_map[type_name]
 
         new_selections: List[SelectionNode] = []


### PR DESCRIPTION
Minor fix, QueryFilter was taking fragment's name instead of the type condition's name.