### PR TITLE
Create subset of a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0 (UNRELEASED)
 
 - Fixed handling of nested variables in objects and lists.
+- Added `queries`, `mutations` and `subscriptions` APIs to `ProxySchema.add_remote_schema`, `ProxySchema.add_schema` and `copy_schema` for creating schemas that are subsets of other, larger schemas.
 
 
 ## 0.3.0 (2024-03-26)

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -445,6 +445,32 @@ app = GraphQL(
 )
 ```
 
+## Creating a schema that is a subset of other schema
+
+Following APIs support creating a new schema that is a subset of another schema:
+
+- `ProxySchema.add_remote_schema`
+- `ProxySchema.add_schema`
+- `copy_schema`
+
+To create a subset of other schema, specify which fields for `queries` and (optionally) `mutations` should be available in final schema:
+
+```python
+from ariadne_graphql_proxy import ProxySchema
+
+proxy_schema = ProxySchema()
+proxy_schema.add_remote_schema(
+    "https://example.com/e-commerce/",
+    queries=["categories", "products"],
+)
+```
+
+All other `Query` fields and types that weren't used by those fields will be removed from the final schema, making it much smaller. If `mutations` option was not used, `Mutation` type will also be removed from the schema.
+
+`queries` and `mutations` arguments can be combined with `exclude_types`, `exclude_fields`, `exclude_args`, `exclude_directives` and `exclude_directives_args`.
+
+
+
 
 ## imgix query params resolver
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -470,8 +470,6 @@ All other `Query` fields and types that weren't used by those fields will be rem
 `queries` and `mutations` arguments can be combined with `exclude_types`, `exclude_fields`, `exclude_args`, `exclude_directives` and `exclude_directives_args`.
 
 
-
-
 ## imgix query params resolver
 
 `get_query_params_resolver` returns a preconfigured resolver that takes URL string and passed arguments to generate a URL with arguments as query params. It can be used to add [rendering options](https://docs.imgix.com/apis/rendering) to [imgix.com](https://imgix.com) image URL.

--- a/ariadne_graphql_proxy/__init__.py
+++ b/ariadne_graphql_proxy/__init__.py
@@ -45,6 +45,7 @@ from .query_filter import QueryFilter, QueryFilterContext
 from .remote_schema import get_remote_schema
 from .resolvers import set_resolver, unset_resolver
 from .selections import merge_selection_sets, merge_selections
+from .unwrap_type import unwrap_graphql_type
 
 __all__ = [
     "ForeignKeyResolver",
@@ -95,4 +96,5 @@ __all__ = [
     "set_resolver",
     "setup_root_resolver",
     "unset_resolver",
+    "unwrap_graphql_type",
 ]

--- a/ariadne_graphql_proxy/copy.py
+++ b/ariadne_graphql_proxy/copy.py
@@ -115,7 +115,7 @@ def copy_schema(
                 schema.directives,
                 exclude_directives=exclude_directives,
                 exclude_directives_args=exclude_directives_args,
-            ),
+            )
         )
 
     new_schema = GraphQLSchema(

--- a/ariadne_graphql_proxy/copy.py
+++ b/ariadne_graphql_proxy/copy.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union, cast
+from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 from graphql import (
     DirectiveNode,

--- a/ariadne_graphql_proxy/copy.py
+++ b/ariadne_graphql_proxy/copy.py
@@ -51,9 +51,9 @@ def copy_schema(
     if queries or mutations or subscriptions:
         return copy_schema_with_subset(
             schema,
-            queries=queries or {},
-            mutations=mutations or {},
-            subscriptions=subscriptions or {},
+            queries=queries or [],
+            mutations=mutations or [],
+            subscriptions=subscriptions or [],
             exclude_types=_copy_arg(exclude_types, []),
             exclude_args=_copy_arg(exclude_args, {}),
             exclude_fields=_copy_arg(exclude_fields, {}),

--- a/ariadne_graphql_proxy/copy.py
+++ b/ariadne_graphql_proxy/copy.py
@@ -1,6 +1,8 @@
-from typing import Dict, List, Optional, Tuple
+from copy import deepcopy
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 from graphql import (
+    DirectiveNode,
     GraphQLArgument,
     GraphQLBoolean,
     GraphQLDirective,
@@ -24,45 +26,367 @@ from graphql import (
 )
 
 from .standard_types import STANDARD_TYPES
+from .output_types import unwrap_output_type
+
+
+ROOTS_ARGS_NAMES = {
+    "Query": "queries",
+    "Mutation": "mutations",
+    "Subscription": "subscriptions",
+}
 
 
 def copy_schema(
     schema: GraphQLSchema,
     *,
+    queries: Optional[List[str]] = None,
+    mutations: Optional[List[str]] = None,
+    subscriptions: Optional[List[str]] = None,
     exclude_types: Optional[List[str]] = None,
     exclude_args: Optional[Dict[str, Dict[str, List[str]]]] = None,
     exclude_fields: Optional[Dict[str, List[str]]] = None,
     exclude_directives: Optional[List[str]] = None,
     exclude_directives_args: Optional[Dict[str, List[str]]] = None,
 ) -> GraphQLSchema:
-    new_types = copy_schema_types(
-        schema,
-        exclude_types=exclude_types,
-        exclude_args=exclude_args,
-        exclude_fields=exclude_fields,
-    )
+    if queries or mutations or subscriptions:
+        roots_dependencies = find_roots_dependencies(
+            schema,
+            {
+                "Query": queries or [],
+                "Mutation": mutations or [],
+                "Subscription": subscriptions or [],
+            },
+            exclude_types,
+            exclude_args,
+            exclude_fields,
+        )
+
+        fin_exclude_types = exclude_types[:] if exclude_types else []
+        for schema_type in schema.type_map:
+            if (
+                schema_type not in roots_dependencies
+                and schema_type not in STANDARD_TYPES
+            ):
+                fin_exclude_types.append(schema_type)
+
+        fin_exclude_fields = deepcopy(exclude_fields) if exclude_fields else {}
+        if queries:
+            fin_exclude_fields.setdefault("Query", [])
+            if schema.query_type:
+                for field_name in schema.query_type.fields:
+                    if field_name not in queries:
+                        fin_exclude_fields["Query"].append(field_name)
+
+        if mutations:
+            fin_exclude_fields.setdefault("Mutation", [])
+            if schema.mutation_type:
+                for field_name in schema.mutation_type.fields:
+                    if field_name not in mutations:
+                        fin_exclude_fields["Mutation"].append(field_name)
+
+        new_types = copy_schema_types(
+            schema,
+            exclude_types=fin_exclude_types,
+            exclude_args=exclude_args,
+            exclude_fields=fin_exclude_fields,
+        )
+    else:
+        new_types = copy_schema_types(
+            schema,
+            exclude_types=exclude_types,
+            exclude_args=exclude_args,
+            exclude_fields=exclude_fields,
+        )
 
     query_type = None
     if schema.query_type:
         query_type = new_types[schema.query_type.name]
 
     mutation_type = None
-    if schema.mutation_type:
+    if schema.mutation_type and schema.mutation_type.name in new_types:
         mutation_type = new_types[schema.mutation_type.name]
+
+    if queries or mutations or subscriptions:
+        new_directives = tuple()
+    else:
+        new_directives = (
+            copy_directives(
+                new_types,
+                schema.directives,
+                exclude_directives=exclude_directives,
+                exclude_directives_args=exclude_directives_args,
+            ),
+        )
 
     new_schema = GraphQLSchema(
         query=query_type,
         mutation=mutation_type,
         types=new_types.values(),
-        directives=copy_directives(
-            new_types,
-            schema.directives,
-            exclude_directives=exclude_directives,
-            exclude_directives_args=exclude_directives_args,
-        ),
+        directives=new_directives,
     )
     assert_valid_schema(new_schema)
     return new_schema
+
+
+def find_roots_dependencies(
+    schema: GraphQLSchema,
+    roots: Dict[str, List[str]],
+    exclude_types: Optional[List[str]] = None,
+    exclude_args: Optional[Dict[str, Dict[str, List[str]]]] = None,
+    exclude_fields: Optional[Dict[str, List[str]]] = None,
+    exclude_directives: Optional[List[str]] = None,
+    exclude_directives_args: Optional[Dict[str, List[str]]] = None,
+) -> List[str]:
+    visitor = TypesDependenciesVisitor(
+        schema,
+        exclude_types,
+        exclude_args,
+        exclude_fields,
+        exclude_directives,
+        exclude_directives_args,
+    )
+
+    return visitor.get_dependencies(roots)
+
+
+class TypesDependenciesVisitor:
+    def __init__(
+        self,
+        schema: GraphQLSchema,
+        exclude_types: Optional[List[str]] = None,
+        exclude_args: Optional[Dict[str, Dict[str, List[str]]]] = None,
+        exclude_fields: Optional[Dict[str, List[str]]] = None,
+        exclude_directives: Optional[List[str]] = None,
+        exclude_directives_args: Optional[Dict[str, List[str]]] = None,
+    ):
+        self.schema = schema
+        self.exclude_types = exclude_types
+        self.exclude_args = exclude_args
+        self.exclude_fields = exclude_fields
+        self.exclude_directives = exclude_directives
+        self.exclude_directives_args = exclude_directives_args
+
+    def exclude_type(self, type_name: str) -> bool:
+        return self.exclude_types and type_name in self.exclude_types
+
+    def exclude_type_field(self, type_name: str, field_name: str) -> bool:
+        return (
+            self.exclude_fields
+            and type_name in self.exclude_fields
+            and field_name in self.exclude_fields[type_name]
+        )
+
+    def exclude_type_field_arg(
+        self, type_name: str, field_name: str, arg_name: str
+    ) -> bool:
+        return (
+            self.exclude_args
+            and type_name in self.exclude_args
+            and field_name in self.exclude_args[type_name]
+            and arg_name in self.exclude_args[type_name][field_name]
+        )
+
+    def exclude_directive(self, type_name: str) -> bool:
+        return self.exclude_directives and type_name in self.exclude_directives
+
+    def exclude_directive_arg(self, type_name: str, arg_name: str) -> bool:
+        return (
+            self.exclude_directives_args
+            and type_name in self.exclude_directives_args
+            and arg_name in self.exclude_directives_args[type_name]
+        )
+
+    def get_dependencies(self, roots: Dict[str, List[str]]) -> List[str]:
+        dependencies: Set[str] = set("Query")
+
+        for root, fields in roots.items():
+            if not fields:
+                continue
+
+            arg_name = ROOTS_ARGS_NAMES[root]
+            dependencies.add(root)
+
+            if root not in self.schema.type_map:
+                raise ValueError(f"Root type '{root}' is not defined by the schema.")
+
+            root_type = cast(GraphQLObjectType, self.schema.type_map[root])
+
+            if root_type.ast_node:
+                self.find_ast_directives_dependencies(
+                    dependencies, root_type.ast_node.directives
+                )
+
+            for field_name in fields:
+                if field_name not in root_type.fields:
+                    raise ValueError(
+                        f"Root type '{root}' is not defining the '{field_name}' field."
+                    )
+
+                if self.exclude_type_field(root, field_name):
+                    raise ValueError(
+                        f"Field '{field_name}' for type '{root}' is specified in both "
+                        f"'exclude_fields' and '{arg_name}'."
+                    )
+
+                field = root_type.fields[field_name]
+                field_type = unwrap_output_type(field.type)
+                if self.exclude_type(field_type.name):
+                    raise ValueError(
+                        f"Field '{field_name}' for type '{root}' that is specified in "
+                        f"'{arg_name}' has a return type '{field_type.name}' that is "
+                        "also specified in 'exclude_types'."
+                    )
+
+                self.find_type_dependencies(dependencies, field_type)
+
+                if field.ast_node:
+                    self.find_ast_directives_dependencies(
+                        dependencies, field.ast_node.directives
+                    )
+
+                for arg_name, arg in field.args.items():
+                    if self.exclude_type_field_arg(root, field_name, arg_name):
+                        continue
+
+                    if arg.ast_node:
+                        self.find_ast_directives_dependencies(
+                            dependencies, arg.ast_node.directives
+                        )
+
+                    arg_type = unwrap_output_type(arg.type)
+                    self.find_type_dependencies(dependencies, arg_type)
+
+        return [dep for dep in dependencies if dep not in STANDARD_TYPES]
+
+    def find_ast_directives_dependencies(
+        self, dependencies: Set[str], directives_ast: Tuple[DirectiveNode]
+    ):
+        for directive in directives_ast:
+            directive_name = directive.name.value
+            directive_type = self.schema.type_map[directive_name]
+            self.find_type_dependencies(dependencies, directive_type)
+
+    def find_type_dependencies(
+        self,
+        dependencies: Set[str],
+        type_def: GraphQLNamedType,
+    ):
+        if type_def.name in dependencies:
+            return
+
+        if isinstance(type_def, GraphQLDirective):
+            self.find_directive_dependencies(dependencies, type_def)
+            return
+
+        if self.exclude_types and type_def.name in self.exclude_types:
+            return
+
+        dependencies.add(type_def.name)
+
+        if isinstance(type_def, GraphQLInputObjectType):
+            self.find_input_type_dependencies(dependencies, type_def)
+
+        if isinstance(type_def, (GraphQLObjectType, GraphQLInterfaceType)):
+            self.find_object_type_dependencies(dependencies, type_def)
+
+        if isinstance(type_def, GraphQLUnionType):
+            self.find_union_type_dependencies(dependencies, type_def)
+
+    def find_directive_dependencies(
+        self,
+        dependencies: Set[str],
+        type_def: GraphQLDirective,
+    ):
+        if self.exclude_directive(type_def.name):
+            return
+
+        dependencies.add(type_def.name)
+
+        for arg_name, arg in type_def.args.items():
+            if self.exclude_directive_arg(type_def.name, arg_name):
+                continue
+
+            arg_type = unwrap_output_type(arg.type)
+            self.find_type_dependencies(dependencies, arg_type)
+
+    def find_input_type_dependencies(
+        self, dependencies: Set[str], type_def: GraphQLInputObjectType
+    ):
+        if type_def.ast_node:
+            self.find_ast_directives_dependencies(
+                dependencies, type_def.ast_node.directives
+            )
+
+        for field_name, field in type_def.fields.items():
+            if self.exclude_type_field(type_def.name, field_name):
+                return
+
+            if field.ast_node:
+                self.find_ast_directives_dependencies(
+                    dependencies, field.ast_node.directives
+                )
+
+            field_type = unwrap_output_type(field.type)
+            self.find_type_dependencies(dependencies, field_type)
+
+    def find_object_type_dependencies(
+        self,
+        dependencies: Set[str],
+        type_def: Union[GraphQLObjectType, GraphQLInterfaceType],
+    ):
+        if type_def.ast_node:
+            self.find_ast_directives_dependencies(
+                dependencies, type_def.ast_node.directives
+            )
+
+        for interface in type_def.interfaces:
+            self.find_type_dependencies(dependencies, interface)
+
+        for field_name, field in type_def.fields.items():
+            self.find_object_type_field_dependencies(
+                dependencies, type_def, field_name, field
+            )
+
+    def find_object_type_field_dependencies(
+        self,
+        dependencies: Set[str],
+        type_def: Union[GraphQLObjectType, GraphQLInterfaceType],
+        field_name: str,
+        field_def: GraphQLField,
+    ):
+        if self.exclude_type_field(type_def.name, field_name):
+            return
+
+        if field_def.ast_node:
+            self.find_ast_directives_dependencies(
+                dependencies, field_def.ast_node.directives
+            )
+
+        field_type = unwrap_output_type(field_def.type)
+        self.find_type_dependencies(dependencies, field_type)
+
+        for arg_name, arg in field_def.args.items():
+            if self.exclude_type_field_arg(type_def.name, field_name, arg_name):
+                continue
+
+            if arg.ast_node:
+                self.find_ast_directives_dependencies(
+                    dependencies, arg.ast_node.directives
+                )
+
+            arg_type = unwrap_output_type(arg.type)
+            self.find_type_dependencies(dependencies, arg_type)
+
+    def find_union_type_dependencies(
+        self, dependencies: Set[str], type_def: GraphQLUnionType
+    ):
+        if type_def.ast_node:
+            self.find_ast_directives_dependencies(
+                dependencies, type_def.ast_node.directives
+            )
+
+        for union_type in type_def._types:
+            self.find_type_dependencies(dependencies, union_type)
 
 
 def copy_schema_types(

--- a/ariadne_graphql_proxy/output_types.py
+++ b/ariadne_graphql_proxy/output_types.py
@@ -1,0 +1,8 @@
+from graphql import GraphQLNamedOutputType, GraphQLOutputType, GraphQLWrappingType
+
+
+def unwrap_output_type(type_: GraphQLOutputType) -> GraphQLNamedOutputType:
+    if isinstance(type_, GraphQLWrappingType):
+        return unwrap_output_type(type_.of_type)
+
+    return type_

--- a/ariadne_graphql_proxy/output_types.py
+++ b/ariadne_graphql_proxy/output_types.py
@@ -1,8 +1,0 @@
-from graphql import GraphQLNamedOutputType, GraphQLOutputType, GraphQLWrappingType
-
-
-def unwrap_output_type(type_: GraphQLOutputType) -> GraphQLNamedOutputType:
-    if isinstance(type_, GraphQLWrappingType):
-        return unwrap_output_type(type_.of_type)
-
-    return type_

--- a/ariadne_graphql_proxy/proxy_schema.py
+++ b/ariadne_graphql_proxy/proxy_schema.py
@@ -64,6 +64,8 @@ class ProxySchema:
         url: str,
         headers: Optional[ProxyHeaders] = None,
         *,
+        queries: Optional[List[str]] = None,
+        mutations: Optional[List[str]] = None,
         exclude_types: Optional[List[str]] = None,
         exclude_args: Optional[Dict[str, Dict[str, List[str]]]] = None,
         exclude_fields: Optional[Dict[str, List[str]]] = None,
@@ -85,6 +87,8 @@ class ProxySchema:
             remote_schema,
             url,
             headers,
+            queries=queries,
+            mutations=mutations,
             exclude_types=exclude_types,
             exclude_args=exclude_args,
             exclude_fields=exclude_fields,
@@ -102,6 +106,8 @@ class ProxySchema:
         url: Optional[str] = None,
         headers: Optional[ProxyHeaders] = None,
         *,
+        queries: Optional[List[str]] = None,
+        mutations: Optional[List[str]] = None,
         exclude_types: Optional[List[str]] = None,
         exclude_args: Optional[Dict[str, Dict[str, List[str]]]] = None,
         exclude_fields: Optional[Dict[str, List[str]]] = None,
@@ -113,7 +119,9 @@ class ProxySchema:
         proxy_extensions: bool = True,
     ) -> int:
         if (
-            exclude_types
+            queries
+            or mutations
+            or exclude_types
             or exclude_args
             or exclude_fields
             or exclude_directives
@@ -121,6 +129,8 @@ class ProxySchema:
         ):
             schema = copy_schema(
                 schema,
+                queries=queries,
+                mutations=mutations,
                 exclude_types=exclude_types,
                 exclude_args=exclude_args,
                 exclude_fields=exclude_fields,

--- a/ariadne_graphql_proxy/proxy_schema.py
+++ b/ariadne_graphql_proxy/proxy_schema.py
@@ -422,7 +422,6 @@ class ProxySchema:
                 isinstance(subquery_data.get("extensions"), dict)
                 and self.proxy_extensions[schema_id]
             ):
-                print("HERE")
                 root_extensions[label] = subquery_data["extensions"]
 
         if root_errors or root_extensions:

--- a/ariadne_graphql_proxy/standard_types.py
+++ b/ariadne_graphql_proxy/standard_types.py
@@ -1,5 +1,12 @@
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLString
 
+STANDARD_DIRECTIVES = (
+    "skip",
+    "include",
+    "deprecated",
+    "specifiedBy",
+)
+
 STANDARD_TYPES = (
     "ID",
     "Boolean",

--- a/ariadne_graphql_proxy/unwrap_type.py
+++ b/ariadne_graphql_proxy/unwrap_type.py
@@ -1,0 +1,14 @@
+from typing import cast
+
+from graphql import (
+    GraphQLType,
+    GraphQLNamedType,
+    GraphQLWrappingType,
+)
+
+
+def unwrap_graphql_type(type_: GraphQLType) -> GraphQLNamedType:
+    if isinstance(type_, GraphQLWrappingType):
+        return unwrap_graphql_type(type_.of_type)
+
+    return cast(GraphQLNamedType, type_)

--- a/tests/test_copy_schema_subset.py
+++ b/tests/test_copy_schema_subset.py
@@ -1,0 +1,701 @@
+import pytest
+from graphql import GraphQLSchema, build_ast_schema, parse, print_schema
+
+from ariadne_graphql_proxy import copy_schema
+
+
+def assert_directive_exists(schema: GraphQLSchema, directive_name: str):
+    assert directive_name in [d.name for d in schema.directives]
+
+
+def assert_directive_doesnt_exist(schema: GraphQLSchema, directive_name: str):
+    assert directive_name not in [d.name for d in schema.directives]
+
+
+def test_copy_schema_subset_excludes_unspecified_root_types(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+
+        type Mutation {
+            echo(val: String!): String!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Mutation" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unspecified_root_fields(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert list(copied_schema.query_type.fields) == ["lorem", "dolor"]
+
+
+def test_copy_schema_subset_raises_exception_for_undefined_root(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    with pytest.raises(ValueError) as exc_info:
+        copy_schema(schema, queries=["lorem", "dolor"], mutations=["echo"])
+
+    assert str(exc_info.value) == ("Root type 'Mutation' is not defined by the schema.")
+
+
+def test_copy_schema_subset_includes_root_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on OBJECT
+
+        type Query @custom {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert_directive_exists(copied_schema, "custom")
+
+
+def test_copy_schema_subset_raises_exception_for_undefined_root_field(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    with pytest.raises(ValueError) as exc_info:
+        copy_schema(schema, queries=["lorem", "echo"])
+
+    assert str(exc_info.value) == (
+        "Root type 'Query' is not defining the 'echo' field."
+    )
+
+
+def test_copy_schema_subset_raises_exception_for_specified_excluded_root_field(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    with pytest.raises(ValueError) as exc_info:
+        copy_schema(
+            schema,
+            queries=["lorem", "dolor"],
+            exclude_fields={"Query": ["dolor"]},
+        )
+
+    assert str(exc_info.value) == (
+        "Field 'dolor' of type 'Query' is specified in both "
+        "'exclude_fields' and 'queries'."
+    )
+
+
+def test_copy_schema_subset_raises_exception_for_specified_type_excluded_root_field(
+    gql,
+):
+    schema_str = gql(
+        """
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Excluded!
+            met: Int!
+        }
+
+        type Excluded {
+            id: ID!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    with pytest.raises(ValueError) as exc_info:
+        copy_schema(
+            schema,
+            queries=["lorem", "dolor"],
+            exclude_types=["Excluded"],
+        )
+
+    assert str(exc_info.value) == (
+        "Field 'dolor' of type 'Query' that is specified in 'queries' has "
+        "a return type 'Excluded' that is also specified in 'exclude_types'."
+    )
+
+
+def test_copy_schema_subset_includes_root_field_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on FIELD_DEFINITION
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int! @custom
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert_directive_exists(copied_schema, "custom")
+
+
+def test_copy_schema_subset_excludes_unused_root_field_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on FIELD_DEFINITION
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int! @custom
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert_directive_doesnt_exist(copied_schema, "custom")
+
+
+def test_copy_schema_subset_includes_used_root_field_enum_type(gql):
+    schema_str = gql(
+        """
+        enum Role {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem: Role!
+            ipsum: Int!
+            dolor: Int!
+            met: Role!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Role" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_enum_type(gql):
+    schema_str = gql(
+        """
+        enum Role {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Role!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Role" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_used_root_field_interface_type(gql):
+    schema_str = gql(
+        """
+        interface Result {
+            id: ID!
+        }
+
+        type Query {
+            lorem: Result!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_interface_type(gql):
+    schema_str = gql(
+        """
+        interface Result {
+            id: ID!
+        }
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_used_root_field_object_type(gql):
+    schema_str = gql(
+        """
+        type Result {
+            id: ID!
+        }
+
+        type Query {
+            lorem: Result!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_object_type(gql):
+    schema_str = gql(
+        """
+        type Result {
+            id: ID!
+        }
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_used_root_field_scalar_type(gql):
+    schema_str = gql(
+        """
+        scalar Money
+
+        type Query {
+            lorem: Money!
+            ipsum: Int!
+            dolor: Int!
+            met: Money!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Money" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_scalar_type(gql):
+    schema_str = gql(
+        """
+        scalar Money
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Money!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Money" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_used_root_field_union_type(gql):
+    schema_str = gql(
+        """
+        type Message {
+            message: String!
+        }
+
+        type User {
+            username: String!
+        }
+
+        union Result = Message | User
+
+        type Query {
+            lorem: Result!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_union_type(gql):
+    schema_str = gql(
+        """
+        type Message {
+            message: String!
+        }
+
+        type User {
+            username: String!
+        }
+
+        union Result = Message | User
+
+        type Query {
+            lorem: Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Result!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Result" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_specified_root_field_arg(gql):
+    schema_str = gql(
+        """
+        type Query {
+            lorem(arg: Int!): Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_args={"Query": {"lorem": ["arg"]}},
+    )
+    assert not copied_schema.type_map["Query"].fields["lorem"].args
+
+
+def test_copy_schema_subset_includes_root_field_arg_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on ARGUMENT_DEFINITION
+
+        type Query {
+            lorem(arg: Int! @custom): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert_directive_exists(copied_schema, "custom")
+
+
+def test_copy_schema_subset_excludes_specified_root_field_arg_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on ARGUMENT_DEFINITION
+
+        type Query {
+            lorem(arg: Int! @custom): Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_args={"Query": {"lorem": ["arg"]}},
+    )
+    assert_directive_doesnt_exist(copied_schema, "custom")
+
+
+def test_copy_schema_subset_excludes_unused_root_field_arg_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on ARGUMENT_DEFINITION
+
+        type Query {
+            lorem: Int!
+            ipsum(arg: Int! @custom): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert_directive_doesnt_exist(copied_schema, "custom")
+
+
+def test_copy_schema_subset_includes_root_field_arg_enum(gql):
+    schema_str = gql(
+        """
+        enum Role {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem(arg: Role!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Role" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_specified_root_field_arg_enum(gql):
+    schema_str = gql(
+        """
+        enum Role {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem(arg: Role!): Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_args={"Query": {"lorem": ["arg"]}},
+    )
+    assert "Role" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_arg_enum(gql):
+    schema_str = gql(
+        """
+        enum Role {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem: Int!
+            ipsum(arg: Role!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Role" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_root_field_arg_input(gql):
+    schema_str = gql(
+        """
+        input Search {
+            query: String
+        }
+
+        type Query {
+            lorem(arg: Search!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Search" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_specified_root_field_arg_input(gql):
+    schema_str = gql(
+        """
+        input Search {
+            query: String
+        }
+
+        type Query {
+            lorem(arg: Search!): Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_args={"Query": {"lorem": ["arg"]}},
+    )
+    assert "Search" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_arg_input(gql):
+    schema_str = gql(
+        """
+        input Search {
+            query: String
+        }
+
+        type Query {
+            lorem: Int!
+            ipsum(arg: Search!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Search" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_includes_root_field_arg_scalar(gql):
+    schema_str = gql(
+        """
+        scalar Money
+
+        type Query {
+            lorem(arg: Money!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Money" in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_specified_root_field_arg_scalar(gql):
+    schema_str = gql(
+        """
+        scalar Money
+
+        type Query {
+            lorem(arg: Money!): Int!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_args={"Query": {"lorem": ["arg"]}},
+    )
+    assert "Money" not in copied_schema.type_map
+
+
+def test_copy_schema_subset_excludes_unused_root_field_arg_scalar(gql):
+    schema_str = gql(
+        """
+        scalar Money
+
+        type Query {
+            lorem: Int!
+            ipsum(arg: Money!): Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(schema, queries=["lorem", "dolor"])
+    assert "Money" not in copied_schema.type_map

--- a/tests/test_copy_schema_subset.py
+++ b/tests/test_copy_schema_subset.py
@@ -771,3 +771,61 @@ def test_copy_schema_subset_excludes_directive_arg_and_type(gql):
 
     directives = {d.name: d for d in copied_schema.directives}
     assert not directives["custom"].args
+
+
+def test_copy_schema_subset_includes_enum_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on ENUM
+
+        enum Role @custom {
+            USER
+            ADMIN
+        }
+
+        type Query {
+            lorem: Role!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_directives=["custom"],
+    )
+    assert "Role" in copied_schema.type_map
+    assert_directive_doesnt_exist(copied_schema, "custom")
+
+
+def test_copy_schema_subset_includes_enum_value_directive(gql):
+    schema_str = gql(
+        """
+        directive @custom on ENUM_VALUE
+
+        enum Role {
+            USER
+            ADMIN @custom
+        }
+
+        type Query {
+            lorem: Role!
+            ipsum: Int!
+            dolor: Int!
+            met: Int!
+        }
+        """
+    )
+    schema = build_ast_schema(parse(schema_str))
+
+    copied_schema = copy_schema(
+        schema,
+        queries=["lorem", "dolor"],
+        exclude_directives=["custom"],
+    )
+    assert "Role" in copied_schema.type_map
+    assert_directive_doesnt_exist(copied_schema, "custom")


### PR DESCRIPTION
This PR adds `queries`, `mutations` and `subscriptions` options to schemas added to the `ProxySchema`. Those can be used to quickly create a small subset of a large remote or local schema.

Fixes #57

# TODO

- [x] Subset schema
- [x] Test
- [x] Docs